### PR TITLE
fix rsync permissions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -694,7 +694,7 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "letters"
-version = "1.2.1"
+version = "1.2.3"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "letters"
-version = "1.2.1"
+version = "1.2.3"
 authors = ["Hugh Rundle <hugh@hughrundle.net>"]
 edition = "2018"
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,7 +75,7 @@ fn default_layout() -> String {
 }
 
 fn default_publish() -> String {
-  String::from("rsync -roptO --del --quiet")
+  String::from("rsync -rtO --del --quiet")
 }
 
 fn default_ssg() -> String {
@@ -594,7 +594,7 @@ fn run(s: String) {
 
   let config: Config = toml::from_str(&s).expect("Error reading Config file");
   let matches = App::new("lette.rs")
-      .version("1.2.1")
+      .version("1.2.3")
       .author("Hugh Rundle")
       .about("A CLI tool to make static site publishing less painful")
       .arg(Arg::with_name("ACTION")


### PR DESCRIPTION
This updated rsync command does not pass through file permissions and ownership from the local machine.
This is less likely to cause read errors on the server.
Also updates the version everywhere.

Fixes #14 