### PR TITLE
explicitly include vendored openssl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ console = "^0.13.0"
 itertools = "^0.9.0"
 reqwest = { version = "^0.11.1", features = ["blocking"] }
 oauth = { version = "0.5", package = "oauth1-request" }
+openssl = { version = "0.10.41", features = ["vendored"] }
 rss = "^1.10.0"
 serde = "^1.0"
 serde_derive = "^1.0"


### PR DESCRIPTION
to avoid Homebrew problems.